### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/georgetown-analytics/product-classifier.png?label=ready&title=Ready)](https://waffle.io/georgetown-analytics/product-classifier)
 # Product Classifier
 
 **Classify products into categories by their name with NLTK**


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/georgetown-analytics/product-classifier

This was requested by a real person (user bbengfort) on waffle.io, we're not trying to spam you.
